### PR TITLE
Make use of generics instead of a method

### DIFF
--- a/spec/negotiator_spec.cr
+++ b/spec/negotiator_spec.cr
@@ -112,6 +112,8 @@ struct NegotiatorTest < NegotiatorTestCase
   def test_ordered_elements(header : String, expected : Indexable(String)) : Nil
     elements = @negotiator.ordered_elements header
 
+    elements.should be_a Array(ANG::Accept)
+
     expected.each_with_index do |element, idx|
       elements[idx].should be_a ANG::Accept
       element.should eq elements[idx].header

--- a/src/charset_negotiator.cr
+++ b/src/charset_negotiator.cr
@@ -1,8 +1,5 @@
 require "./abstract_negotiator"
 
 # A `ANG::AbstractNegotiator` implementation to negotiate `ANG::AcceptCharset` headers.
-class Athena::Negotiation::CharsetNegotiator < Athena::Negotiation::AbstractNegotiator
-  private def create_header(header : String) : ANG::BaseAccept
-    ANG::AcceptCharset.new header
-  end
+class Athena::Negotiation::CharsetNegotiator < Athena::Negotiation::AbstractNegotiator(Athena::Negotiation::AcceptCharset)
 end

--- a/src/encoding_negotiator.cr
+++ b/src/encoding_negotiator.cr
@@ -1,8 +1,5 @@
 require "./abstract_negotiator"
 
 # A `ANG::AbstractNegotiator` implementation to negotiate `ANG::AcceptEncoding` headers.
-class Athena::Negotiation::EncodingNegotiator < Athena::Negotiation::AbstractNegotiator
-  private def create_header(header : String) : ANG::BaseAccept
-    ANG::AcceptEncoding.new header
-  end
+class Athena::Negotiation::EncodingNegotiator < Athena::Negotiation::AbstractNegotiator(Athena::Negotiation::AcceptEncoding)
 end

--- a/src/language_negotiator.cr
+++ b/src/language_negotiator.cr
@@ -1,7 +1,7 @@
 require "./abstract_negotiator"
 
 # A `ANG::AbstractNegotiator` implementation to negotiate `ANG::AcceptLanguage` headers.
-class Athena::Negotiation::LanguageNegotiator < Athena::Negotiation::AbstractNegotiator
+class Athena::Negotiation::LanguageNegotiator < Athena::Negotiation::AbstractNegotiator(Athena::Negotiation::AcceptLanguage)
   protected def match(accept : ANG::AcceptLanguage, priority : ANG::AcceptLanguage, index : Int32) : ANG::AcceptMatch?
     accept_base = accept.language
     priority_base = priority.language
@@ -19,9 +19,5 @@ class Athena::Negotiation::LanguageNegotiator < Athena::Negotiation::AbstractNeg
     end
 
     nil
-  end
-
-  private def create_header(header : String) : ANG::BaseAccept
-    ANG::AcceptLanguage.new header
   end
 end

--- a/src/negotiator.cr
+++ b/src/negotiator.cr
@@ -1,7 +1,7 @@
 require "./abstract_negotiator"
 
 # A `ANG::AbstractNegotiator` implementation to negotiate `ANG::Accept` headers.
-class Athena::Negotiation::Negotiator < Athena::Negotiation::AbstractNegotiator
+class Athena::Negotiation::Negotiator < Athena::Negotiation::AbstractNegotiator(Athena::Negotiation::Accept)
   # TODO: Make this method less complex.
   #
   # ameba:disable Metrics/CyclomaticComplexity
@@ -62,9 +62,5 @@ class Athena::Negotiation::Negotiator < Athena::Negotiation::AbstractNegotiator
     return [sub_type, ""] unless sub_type.includes? '+'
 
     sub_type.split '+', limit: 2
-  end
-
-  private def create_header(header : String) : ANG::BaseAccept
-    ANG::Accept.new header
   end
 end


### PR DESCRIPTION
* Allows Crystal to more accurately know the return type of `ordered_elements`
* Add example of `ordered_elements` usage